### PR TITLE
use babashka.http-client for simpler use

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ To see what the default Babashka version and platform are, run:
 bb blambda build-runtime-layer --help
 ```
 
-To build a custom runtime with Babashka 0.8.2 on amd64, run:
+To build a custom runtime with Babashka 1.1.173 on amd64, run:
 
 ``` sh
-bb blambda build-runtime-layer --bb-version 0.8.2 --bb-arch arm64
+bb blambda build-runtime-layer --bb-version 1.1.173 --bb-arch arm64
 ```
 
 ### Dependencies

--- a/resources/bootstrap.clj
+++ b/resources/bootstrap.clj
@@ -2,7 +2,7 @@
 ;;
 ;;  The bootstrap shell script will run this
 
-(require '[org.httpkit.client :as http]
+(require '[babashka.http-client :as http]
          '[clojure.string :as str]
          '[cheshire.core :as cheshire])
 
@@ -42,21 +42,21 @@
   "Get the next invocation, returns payload and fn to respond."
   []
   (let [{:keys [headers body]}
-        @(http/get (str runtime-api-url "invocation/next")
-                   {:timeout timeout-ms
-                    :as :text})
+        (http/get (str runtime-api-url "invocation/next")
+                  {:timeout timeout-ms
+                   :as :text})
         id (:lambda-runtime-aws-request-id headers)]
     {:event (cheshire/decode body keyword)
      :context headers
      :send-response!
      (fn [response]
-       @(http/post (str runtime-api-url "invocation/" id "/response")
-                   {:body (cheshire/encode response)}))
+       (http/post (str runtime-api-url "invocation/" id "/response")
+                  {:body (cheshire/encode response)}))
      :send-error!
      (fn [thrown]
-       @(http/post (str runtime-api-url "invocation/" id "/error")
-                   {:body (cheshire/encode
-                           (throwable->error-body thrown))}))}))
+       (http/post (str runtime-api-url "invocation/" id "/error")
+                  {:body (cheshire/encode
+                          (throwable->error-body thrown))}))}))
 
 (when handler
   (println "Starting babashka lambda event loop")

--- a/resources/bootstrap.clj
+++ b/resources/bootstrap.clj
@@ -43,8 +43,7 @@
   []
   (let [{:keys [headers body]}
         (http/get (str runtime-api-url "invocation/next")
-                  {:timeout timeout-ms
-                   :as :text})
+                  {:timeout timeout-ms})
         id (:lambda-runtime-aws-request-id headers)]
     {:event (cheshire/decode body keyword)
      :context headers

--- a/src/blambda/api.clj
+++ b/src/blambda/api.clj
@@ -1,6 +1,6 @@
 (ns blambda.api
   (:require [babashka.deps :refer [clojure]]
-            [babashka.curl :as curl]
+            [babashka.http-client :as http]
             [babashka.fs :as fs]
             [babashka.process :refer [shell]]
             [blambda.internal :as lib]
@@ -68,7 +68,7 @@
         (when-not (fs/exists? bb-tarball)
           (println "Downloading" bb-url)
           (io/copy
-           (:body (curl/get bb-url {:as :bytes}))
+           (:body (http/get bb-url {:as :stream}))
            (io/file bb-tarball)))
 
         (println "Decompressing" bb-tarball "to" work-dir)

--- a/src/blambda/cli.clj
+++ b/src/blambda/cli.clj
@@ -17,7 +17,7 @@
    {:cmds #{:build-runtime-layer :build-all :terraform-write-config}
     :desc "Babashka version"
     :ref "<version>"
-    :default "1.0.168"}
+    :default "1.1.173 "}
 
    :deps-layer-name
    {:cmds #{:build-deps-layer :build-all :terraform-write-config}


### PR DESCRIPTION
this hopefully should make the code simpler and more efficient. we are planning to deprecate httpkit client and most of babashka curl in favour of http-client. this makes it require bb 1.1.171+, ~wasnt sure where i can change that?~ found it.