### PR TITLE
Add support for bb snapshot versions

### DIFF
--- a/src/blambda/internal.clj
+++ b/src/blambda/internal.clj
@@ -11,8 +11,9 @@
             "linux-amd64-static")))
 
 (defn bb-url [bb-version filename]
-  (format "https://github.com/babashka/babashka/releases/download/v%s/%s"
-          bb-version filename))
+  (format "https://github.com/babashka/%s/releases/download/v%s/%s"
+          (if (str/includes? bb-version "SNAPSHOT") "babashka-dev-builds" "babashka")
+           bb-version filename))
 
 (defn zipfile [{:keys [target-dir]} layer-name]
   (fs/file (-> (fs/file target-dir) .getAbsolutePath)


### PR DESCRIPTION
Example:

```bash
bb build --bb-version 0.8.158-SNAPSHOT
```