### PR TITLE
Add --skip-compatible-architectures for restricted environments

### DIFF
--- a/resources/blambda.tf
+++ b/resources/blambda.tf
@@ -1,5 +1,7 @@
 variable "runtime_layer_name" {}
+{% if not skip-compatible-architectures %}
 variable "runtime_layer_compatible_architectures" {}
+{% endif %}
 variable "runtime_layer_compatible_runtimes" {}
 variable "runtime_layer_filename" {}
 {% if use-s3 %}
@@ -8,7 +10,9 @@ variable "runtime_layer_s3_key" {}
 {% endif %}
 {% if deps-layer-name %}
 variable "deps_layer_name" {}
+{% if not skip-compatible-architectures %}
 variable "deps_layer_compatible_architectures" {}
+{% endif %}
 variable "deps_layer_compatible_runtimes" {}
 variable "deps_layer_filename" {}
 {% if use-s3 %}
@@ -43,7 +47,9 @@ module "runtime" {
   source = "./{{tf-module-dir}}"
 
   layer_name = var.runtime_layer_name
+{% if not skip-compatible-architectures %}
   compatible_architectures = var.runtime_layer_compatible_architectures
+{% endif %}
   compatible_runtimes = var.runtime_layer_compatible_runtimes
   filename = var.runtime_layer_filename
 {% if use-s3 %}
@@ -57,7 +63,9 @@ module "deps" {
   source = "./{{tf-module-dir}}"
 
   layer_name = var.deps_layer_name
+{% if not skip-compatible-architectures %}
   compatible_architectures = var.deps_layer_compatible_architectures
+{% endif %}
   compatible_runtimes = var.deps_layer_compatible_runtimes
   filename = var.deps_layer_filename
 {% if use-s3 %}

--- a/resources/blambda.tfvars
+++ b/resources/blambda.tfvars
@@ -1,9 +1,11 @@
 runtime_layer_name = "{{runtime-layer-name}}"
+{% if not skip-compatible-architectures %}
 runtime_layer_compatible_architectures = [
   {% for a in runtime-layer-compatible-architectures %}
   "{{a}}",
   {% endfor %}
 ]
+{% endif %}
 runtime_layer_compatible_runtimes = [
   {% for r in runtime-layer-compatible-runtimes %}
   "{{r}}",
@@ -17,11 +19,14 @@ runtime_layer_s3_key = "{{runtime-layer-s3-key}}"
 
 {% if deps-layer-name %}
 deps_layer_name = "{{deps-layer-name}}"
+{% if not skip-compatible-architectures %}
 deps_layer_compatible_architectures = [
   {% for a in deps-layer-compatible-architectures %}
   "{{a}}",
   {% endfor %}
 ]
+{% endif %}
+
 deps_layer_compatible_runtimes = [
   {% for r in deps-layer-compatible-runtimes %}
   "{{r}}",

--- a/resources/lambda_layer.tf
+++ b/resources/lambda_layer.tf
@@ -1,5 +1,7 @@
 variable "layer_name" {}
+{% if not skip-compatible-architectures %}
 variable "compatible_architectures" {}
+{% endif %}
 variable "compatible_runtimes" {}
 variable "filename" {}
 {% if use-s3 %}
@@ -10,7 +12,9 @@ variable "s3_key" {}
 resource "aws_lambda_layer_version" "layer" {
   layer_name = var.layer_name
   source_code_hash = filebase64sha256(var.filename)
+{% if not skip-compatible-architectures %}
   compatible_architectures = var.compatible_architectures
+{% endif %}
   compatible_runtimes = var.compatible_runtimes
 {% if use-s3 %}
   s3_bucket = aws_s3_object.object.bucket

--- a/src/blambda/cli.clj
+++ b/src/blambda/cli.clj
@@ -89,6 +89,11 @@
     :desc "Bucket to use for S3 artifacts (if using S3)"
     :ref "<bucket>"}
 
+   :skip-compatible-architectures
+   {:cmds #{:terraform-write-config}
+    :desc "Skips generating compatible_architectures stanzas when not supported"
+    :coerce :boolean}
+
    :source-dir
    {:cmds #{:build-lambda :build-all}
     :desc "Lambda source directory"


### PR DESCRIPTION
Some AWS regions have not enabled multiple architectures yet. This provides the ability to skip generating the "compatible-architectures" stanza for those cases.