### PR TITLE
[fix] fix request id retrieval

### DIFF
--- a/resources/bootstrap.clj
+++ b/resources/bootstrap.clj
@@ -44,7 +44,7 @@
   (let [{:keys [headers body]}
         (http/get (str runtime-api-url "invocation/next")
                   {:timeout timeout-ms})
-        id (:lambda-runtime-aws-request-id headers)]
+        id (get headers "lambda-runtime-aws-request-id")]
     {:event (cheshire/decode body keyword)
      :context headers
      :send-response!


### PR DESCRIPTION
This fixes the way the request id is retrieved. This regression was potentially introduced when the http client was switched to the inbuilt bb http-client. That unlike http kit doesn't auto coerce the header keys to keywords.