### PR TITLE
FIX directory creation in build-deps-layer and build-lambda

### DIFF
--- a/src/blambda/api.clj
+++ b/src/blambda/api.clj
@@ -17,8 +17,8 @@
                        (str deps-path) (str deps-zipfile)))
       (do
         (println "\nBuilding dependencies layer:" (str deps-zipfile))
-        (fs/create-dirs target-dir work-dir)
-
+        (doseq [dir [target-dir work-dir]]
+          (fs/create-dirs dir))
         (let [gitlibs-dir "gitlibs"
               m2-dir "m2-repo"
               deps (->> deps-path slurp edn/read-string :deps)]
@@ -96,6 +96,8 @@
                source-files)
       (do
         (println "\nBuilding lambda artifact:" (str lambda-zipfile))
+        (doseq [dir [target-dir work-dir]]
+          (fs/create-dirs dir))
         (lib/copy-files! opts source-files)
         (println "Compressing lambda:" (str lambda-zipfile))
         (apply shell {:dir work-dir}

--- a/src/blambda/cli.clj
+++ b/src/blambda/cli.clj
@@ -17,7 +17,7 @@
    {:cmds #{:build-runtime-layer :build-all :terraform-write-config}
     :desc "Babashka version"
     :ref "<version>"
-    :default "1.1.173 "}
+    :default "1.1.173"}
 
    :deps-layer-name
    {:cmds #{:build-deps-layer :build-all :terraform-write-config}


### PR DESCRIPTION
When build-deps-layer or build-lambda is executed in a clean directory, they both fail because work-dir and/or target-dir are not created. This was probably not reported, because if user does build-all (or previously has done build-runtime-layer) the folders are created by build-runtime-layer and everything seems to work ok.