### PR TITLE
FIX extra space in bb version number and maybe upgrade?

### DIFF
--- a/src/blambda/cli.clj
+++ b/src/blambda/cli.clj
@@ -17,7 +17,7 @@
    {:cmds #{:build-runtime-layer :build-all :terraform-write-config}
     :desc "Babashka version"
     :ref "<version>"
-    :default "1.1.173 "}
+    :default "1.3.186"}
 
    :deps-layer-name
    {:cmds #{:build-deps-layer :build-all :terraform-write-config}


### PR DESCRIPTION
There is currently an extra space character at the end of the default bb version number which causes the build-runtime-layer to fail (if the default is used). Please fix this. And maybe bump bb to the latest version also? Not sure about this part though as I have not done any regression tests with the latest bb.