### PR TITLE
Build Lambda: Parent directories aren't added to working directory correctly

### DIFF
--- a/src/blambda/internal.clj
+++ b/src/blambda/internal.clj
@@ -56,9 +56,11 @@
                               resource? (io/resource f)
                               source-dir (fs/file source-dir f)
                               :else f)
-                parent (fs/parent f)]]
+                parent (if (and work-dir (fs/parent f)) (fs/file work-dir (fs/parent f)) (fs/parent f))]]
     (println "Adding file:" (str f))
     (when parent
       (fs/create-dirs parent))
     (fs/delete-if-exists (fs/file work-dir f))
-    (fs/copy source-file work-dir)))
+    (if parent
+      (fs/copy source-file parent)
+      (fs/copy source-file work-dir))))


### PR DESCRIPTION
To reproduce:
- Take a small project with a parent directory inside src: [test-project.zip](https://github.com/jmglov/blambda/files/13718202/test-project.zip)
- run `bb blambda build-runtime-layer`
- run `bb blambda build-lambda`

Issue:
- Notice all source files are added to .work without their parent directory (if applicable)
- Notice parent directory is created outside of .work and is empty

Proposed Change:
- Includes working directory in the parent definition if it's available
- Copies source files to parent if it's available

