### PR TITLE
Should merge deps layer architectures in tfvars generation

### DIFF
--- a/src/blambda/api/terraform.clj
+++ b/src/blambda/api/terraform.clj
@@ -35,10 +35,10 @@
               {:lambda-s3-key (lib/s3-artifact opts lambda-filename)
                :runtime-layer-s3-key (lib/s3-artifact opts runtime-filename)})
             (when deps-layer-name
-              (when-not skip-compatible-architectures
-                {:deps-layer-compatible-architectures (lib/deps-layer-architectures opts)})
-              {:deps-layer-compatible-runtimes (lib/deps-layer-runtimes opts)
-               :deps-layer-filename deps-zipfile})
+              (merge {:deps-layer-compatible-runtimes (lib/deps-layer-runtimes opts)
+                      :deps-layer-filename deps-zipfile}
+                     (when-not skip-compatible-architectures
+                       {:deps-layer-compatible-architectures (lib/deps-layer-architectures opts)})))
             (when (and deps-layer-name use-s3)
               {:deps-layer-s3-key (lib/s3-artifact opts deps-filename)})))))
 


### PR DESCRIPTION
Fix working for my arm64 lambdas.

Commit and description are AI generated.

 **Problem**
  Blambda’s terraform generation dropped deps-layer-compatible-architectures. The when deps-layer-name form returned only the last map in the body, so the architectures map was evaluated then discarded. As a result, deps layers were emitted with an empty architectures list, defaulting to x86_64 in AWS and breaking ARM64 lambdas.

Error message:
```
  /opt/bootstrap: line 27: /opt/bb: cannot execute binary file
  Runtime.ExitError: Runtime exited with error: exit status 126
```

**Repro**

  1. Unpatched blambda v0.2.0; lambda configured for ARM64 (e.g., :bb-arch "arm64" in its bb.edn) and Terraform lambda set to ["arm64"].
  2. Run the normal blambda generation (write-config/deploy hook).
  3. Check the generated blambda.auto.tfvars: runtime shows ["arm64"] but deps_layer_compatible_architectures is empty.
  4. Apply Terraform; the deps layer publishes with the default x86_64.
  5. Invoke the ARM64 lambda; it pulls the x86 deps layer and fails:
```
     /opt/bootstrap: line 27: /opt/bb: cannot execute binary file
     Runtime.ExitError: exit status 126
```

**Fix**
Merge the deps-layer maps so architectures are included when skip-compatible-architectures is false:
  - In blambda/src/blambda/api/terraform.clj, wrap the deps-layer maps in merge and add the architectures map conditionally.

This ensures generated tfvars include both architectures (or whatever lib/deps-layer-architectures returns) and deploy correctly for ARM64.